### PR TITLE
Fix: pascal_case() formatter breaks PascalCase capitalization when adding prefix

### DIFF
--- a/compiler/bitproto/utils.py
+++ b/compiler/bitproto/utils.py
@@ -343,16 +343,19 @@ def pascal_case(word: str) -> str:
 
     >>> pascal_case("someWord")
     "SomeWord"
+
+    >>> pascal_case("my_prefix_someWord")
+    "MyPrefixSomeWord"
     """
     items: List[str] = []
     parts = word.split("_")
-    contains_underscore = len(parts) > 1
+
     for part in parts:
         if part:
-            if contains_underscore:
-                items.append(part.title())
-            else:
-                first_char, remain_part = part[0], part[1:]
+            first_char, remain_part = part[0], part[1:]
+            if remain_part and remain_part.isupper():  # UPPERCASE
+                items.append(first_char.upper() + remain_part.lower())
+            else:  # flatcase or camelCase or PascalCase
                 items.append(first_char.upper() + remain_part)
     return "".join(items)
 


### PR DESCRIPTION
See #68, specifically [this comment](https://github.com/hit9/bitproto/issues/68#issuecomment-3219647987).

This PR fixes the issue described in the comment, however it comes with 2 caveats:
- Although the documentation does not cover this behavior, I would consider this a breaking change, as any existing project using a combination of PascalCase-messages and `option c.name_prefix = <something with '_'>` would need to adjust to the new capitalization.
- Given that all tests continue pass without issue, right now this behavior is clearly not covered by any test.

I'm in no position to decide how to go about this, so I'll leave that up to you. Do with this PR as you see fit.