### PR TITLE
Fix: type to format mapping only accepts exact match

### DIFF
--- a/compiler/bitproto/renderer/impls/c/formatter.py
+++ b/compiler/bitproto/renderer/impls/c/formatter.py
@@ -34,13 +34,15 @@ class CFormatter(Formatter):
 
     @override(Formatter)
     def case_style_mapping(self) -> CaseStyleMapping:
-        return {
-            Constant: "upper",
-            Alias: "pascal",
-            Enum: "pascal",
-            EnumField: ("snake", "upper"),
-            Message: "pascal",
-        }
+        return CaseStyleMapping(
+            {
+                Constant: "upper",
+                Alias: "pascal",
+                Enum: "pascal",
+                EnumField: ("snake", "upper"),
+                Message: "pascal",
+            }
+        )
 
     @override(Formatter)
     def indent_character(self) -> str:

--- a/compiler/bitproto/renderer/impls/go/formatter.py
+++ b/compiler/bitproto/renderer/impls/go/formatter.py
@@ -34,13 +34,15 @@ class GoFormatter(Formatter):
 
     @override(Formatter)
     def case_style_mapping(self) -> CaseStyleMapping:
-        return {
-            Alias: "pascal",
-            Constant: "upper",
-            EnumField: ("snake", "upper"),
-            Message: "pascal",
-            MessageField: "pascal",
-        }
+        return CaseStyleMapping(
+            {
+                Alias: "pascal",
+                Constant: "upper",
+                EnumField: ("snake", "upper"),
+                Message: "pascal",
+                MessageField: "pascal",
+            }
+        )
 
     @override(Formatter)
     def indent_character(self) -> str:

--- a/compiler/bitproto/renderer/impls/py/formatter.py
+++ b/compiler/bitproto/renderer/impls/py/formatter.py
@@ -28,10 +28,12 @@ class PyFormatter(Formatter):
 
     @override(Formatter)
     def case_style_mapping(self) -> CaseStyleMapping:
-        return {
-            Constant: "upper",
-            EnumField: ("snake", "upper"),
-        }
+        return CaseStyleMapping(
+            {
+                Constant: "upper",
+                EnumField: ("snake", "upper"),
+            }
+        )
 
     @override(Formatter)
     def indent_character(self) -> str:


### PR DESCRIPTION
Partly addresses #68.

---

Issue:
- Fetching a derived type (e.g. `IntegerConstant`) resulted in no match, even if the dictionary has a value for `Constant`.
- This made it so that combining `option c.name_prefix = "lowercase"` with `const MY_CONST = 42;` would result in `#define lowercaseMY_CONST 42`, as it would leave the capitalization untouched.

Fix:
- Traverse the `key`'s `__mro__`, perform a lookup of each base type and return the first (and therefore best) match.
- Note: exact type matches are still prioritized.

Suggestion:
- Currently the c-formatter maps `Constant: "upper"`, however `Constant: ("snake", "upper")` seems like the more fitting option to me. Thoughts?