### PR TITLE
improve the snake_case()

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: bitproto
 
+Version 1.2.2
+-------------
+
+.. _version-1.2.2:
+
+Warning: May break some existing projects's generated names:
+
+- Improve `snake_case` function. #74, #75
+
 Version 1.2.1
 -------------
 

--- a/compiler/bitproto/__init__.py
+++ b/compiler/bitproto/__init__.py
@@ -8,5 +8,5 @@ Bit level data interchange format.
 
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __description__ = "bit level data interchange format."

--- a/compiler/bitproto/utils.py
+++ b/compiler/bitproto/utils.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import re
 import sys
@@ -360,14 +361,8 @@ def pascal_case(word: str) -> str:
     return "".join(items)
 
 
-_snake_case_regex_head = r"[A-Z0-9]"
-_snake_case_regex_tail = r"[^A-Z0-9]"
-_snake_case_regex_capital_match = re.compile(
-    rf"({_snake_case_regex_head}+{_snake_case_regex_tail}*)"
-)
-_snake_case_regex_m_capital_match = re.compile(
-    rf"^({_snake_case_regex_head}{{1,}})({_snake_case_regex_head}+{_snake_case_regex_tail}+)$"
-)
+# Uppercase preceded by a lowercase marks the start of a new camelCase word
+_snake_case_regex_camel_match = re.compile(r"(?<=[a-z])([A-Z]+[a-z0-9]*)")
 
 
 def snake_case(word: str) -> str:
@@ -376,23 +371,12 @@ def snake_case(word: str) -> str:
     >>> snake_case("someWord")
     "some_word"
     """
-    underscore = "_"
-    no_underscore_words = word.split(underscore)
-    no_underscore_cases: List[str] = []
+    snake_case_split: List[str] = word.split("_")
 
-    for w in no_underscore_words:
-        cases = filter(None, _snake_case_regex_capital_match.split(w))
-        for case in cases:
-            subcases = filter(None, _snake_case_regex_m_capital_match.split(case))
-            if subcases:
-                for subcase in subcases:
-                    no_underscore_cases.append(subcase)
-            else:
-                no_underscore_cases.append(case)
-
-    snake_word = ""
-    for case in no_underscore_cases:
-        if not case.isdigit():
-            snake_word += underscore
-        snake_word += case
-    return snake_word.strip(underscore).lower()
+    camel_case_split: List[str] = list(
+        itertools.chain.from_iterable(
+            filter(None, _snake_case_regex_camel_match.split(w))
+            for w in snake_case_split
+        )
+    )
+    return "_".join(camel_case_split).lower()

--- a/compiler/bitproto/utils.py
+++ b/compiler/bitproto/utils.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import re
 import sys

--- a/tests/test_compiler/test_util.py
+++ b/tests/test_compiler/test_util.py
@@ -133,6 +133,7 @@ def test_snake_case() -> None:
     assert snake_case("SnakeCase") == "snake_case"
     assert snake_case("snakeCase") == "snake_case"
     assert snake_case("SNAKE_CASE") == "snake_case"
+    assert snake_case("SNAKE_42_CASE") == "snake_42_case"
 
 
 def test_cast_or_raise() -> None:

--- a/tests/test_compiler/test_util.py
+++ b/tests/test_compiler/test_util.py
@@ -129,11 +129,36 @@ def test_pascal_case() -> None:
 
 
 def test_snake_case() -> None:
+    assert snake_case("") == ""
+    assert snake_case("123") == "123"
+    assert snake_case("A") == "a"
     assert snake_case("snake_case") == "snake_case"
     assert snake_case("SnakeCase") == "snake_case"
     assert snake_case("snakeCase") == "snake_case"
     assert snake_case("SNAKE_CASE") == "snake_case"
     assert snake_case("SNAKE_42_CASE") == "snake_42_case"
+    assert snake_case("HTTPServer") == "http_server"
+    assert snake_case("getHTTPResponseCode") == "get_http_response_code"
+    assert snake_case("Mixed_SnakeCase") == "mixed_snake_case"
+    assert snake_case("Snake42Case") == "snake_42_case"
+    assert snake_case("xY") == "x_y"
+    assert snake_case("Xy") == "xy"
+    assert snake_case("Id") == "id"
+    assert snake_case("__Init__") == "__init__"
+    assert snake_case("__") == "__"
+    assert snake_case("foo__bar") == "foo_bar"
+    assert snake_case("already_snake_case") == "already_snake_case"
+    assert snake_case("kebab-case-here") == "kebab_case_here"
+    assert snake_case("Ipv6Address") == "ipv_6_address"
+    assert snake_case("Ipv6_Address") == "ipv6_address"
+    assert snake_case("MyMessage_v1") == "my_message_v1"
+    assert snake_case("camelCase123") == "camel_case_123"
+    assert snake_case("_privateVariable") == "_private_variable"
+    assert snake_case("GPU3DModel") == "gpu_3_d_model"
+    assert snake_case("TI82") == "ti82"
+    assert snake_case("TI82_PLUS") == "ti82_plus"
+    assert snake_case("MyMessage_mk2") == "my_message_mk2"
+    assert snake_case("MY_VALUE1") == "my_value1"
 
 
 def test_cast_or_raise() -> None:


### PR DESCRIPTION
- **Fix: pascal_case() formatter breaks PascalCase-message capitalization when adding prefix**
- **Fix: type to format mapping only accepts exact match**
- **add tests for https://github.com/hit9/bitproto/pull/69**
- **add changelog**
- **add test for https://github.com/hit9/bitproto/pull/70**
- **add changelog**
- **bump v1.2.1**
- **ci: add go1.25, py3.13, remove: go1.19, py3.10**
- **Add failing test**
- **Fix: numbers in uppercase are merged with previous word. Refactor.**
- **improve the util:snake_case**
