### PR TITLE
fix: extend BP_BIG_ENDIAN auto-detection to cover TI ARM CGT

### DIFF
--- a/compiler/bitproto/renderer/impls/c/renderer_c.py
+++ b/compiler/bitproto/renderer/impls/c/renderer_c.py
@@ -411,8 +411,11 @@ class BlockIncludeOpMode(Block[F]):
         if endian == "both":
             # Auto-detect a big-endian host so the default just works without
             # the user defining BP_BIG_ENDIAN; still overridable via -D.
-            self.push("#if !defined(BP_BIG_ENDIAN) && defined(__BYTE_ORDER__) && \\")
-            self.push("    (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)")
+            # __BYTE_ORDER__ / __ORDER_BIG_ENDIAN__ covers GCC/Clang.
+            # __BIG_ENDIAN__ covers TI ARM CGT (--be32) and some other toolchains.
+            self.push("#if !defined(BP_BIG_ENDIAN) && (\\")
+            self.push("    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \\")
+            self.push("    defined(__BIG_ENDIAN__))")
             self.push("#define BP_BIG_ENDIAN 1")
             self.push("#endif")
             # <string.h> is only needed for memset in the big-endian path.

--- a/compiler/bitproto/renderer/impls/c/renderer_c.py
+++ b/compiler/bitproto/renderer/impls/c/renderer_c.py
@@ -414,7 +414,9 @@ class BlockIncludeOpMode(Block[F]):
             # __BYTE_ORDER__ / __ORDER_BIG_ENDIAN__ covers GCC/Clang.
             # __BIG_ENDIAN__ covers TI ARM CGT (--be32) and some other toolchains.
             self.push("#if !defined(BP_BIG_ENDIAN) && (\\")
-            self.push("    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \\")
+            self.push(
+                "    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \\"
+            )
             self.push("    defined(__BIG_ENDIAN__))")
             self.push("#define BP_BIG_ENDIAN 1")
             self.push("#endif")


### PR DESCRIPTION
The existing check only recognised GCC/Clang's __BYTE_ORDER__ / __ORDER_BIG_ENDIAN__ pair.  TI's ARM CGT compiler (used with --be32 for big-endian Cortex-R targets such as the TMS570) does not define those macros; it defines __BIG_ENDIAN__ instead.

Without this fix the dual-path codegen (endian="both") falls through to the #ifndef BP_BIG_ENDIAN (little-endian byte-pointer) branch on TI big-endian targets, producing incorrect encode/decode results for multi-byte fields.

Add __BIG_ENDIAN__ as a second detection arm so BP_BIG_ENDIAN is set correctly on TI CGT and other toolchains that follow the same convention.